### PR TITLE
BUG-UI-004945 Cross-Frame Scripting (XFS)

### DIFF
--- a/dev_setup/cookbooks/nginx_v2/templates/default/router-nginx.conf.erb
+++ b/dev_setup/cookbooks/nginx_v2/templates/default/router-nginx.conf.erb
@@ -117,7 +117,7 @@ http {
     # end of http-chunkin
 
     listen       80;
-    add_header X-FRAME-OPTIONS 'SAMEORIGIN';
+    more_set_headers  'X-FRAME-OPTIONS: SAMEORIGIN';
     client_max_body_size 1024M;
     server_name  _;
     server_name_in_redirect off;
@@ -258,7 +258,7 @@ http {
     # end of http-chunkin
 
     listen      443;
-    add_header  X-FRAME-OPTIONS 'SAMEORIGIN';
+    more_set_headers  'X-FRAME-OPTIONS: SAMEORIGIN';
     ssl         on;
     ssl_certificate <%= node[:nginx][:ssl][:config_dir] %>/<%= node[:nginx][:ssl][:basename] %>.crt;
     ssl_certificate_key <%= node[:nginx][:ssl][:config_dir] %>/<%= node[:nginx][:ssl][:basename] %>.key;


### PR DESCRIPTION
add_header directive only can add header for response message whose status code is 200,201,204,206,301,302,303,304 or 307, can't set header for response message whose status code is 404. need use more_set_header directive, it can set header for 404 message